### PR TITLE
Fix title that had wandered in from another post

### DIFF
--- a/content/tech/domain-frontend.md
+++ b/content/tech/domain-frontend.md
@@ -12,7 +12,7 @@ code?
 --------------------------------------------------------------------------------
 :section/kind :centered
 :section/theme :dark1
-:section/title Zero downtime Kubernetes deployments
+:section/title What's the domain of the frontend?
 :section/body
 
 A prerequisite for hitting the mark with software design is having good control


### PR DESCRIPTION
Fix the title.

This post has another issue which I would've liked to have fixed: the code under "The finished DropdownMenu component" heading is not a `DropdownMenu` at all! It doesn't have the `:icon-size` that's mentioned in the prose below the code. Could you update with the actual `DropdownMenu` please @cjohansen ?